### PR TITLE
fix(matching): Handle case where Netflix shortens long titles

### DIFF
--- a/internal/activitytracker/client_test.go
+++ b/internal/activitytracker/client_test.go
@@ -295,6 +295,12 @@ func TestStringMatches(t *testing.T) {
 			trakt:       "Arrested Development: Forget-Me-Now",
 			shouldMatch: true,
 		},
+		{
+			name:        "incomplete title",
+			netflix:     "A Special Episode - Death: The High Cos...",
+			trakt:       "A Special Episode - Death: The High Cost of Living",
+			shouldMatch: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Netflix episode's name: `A Special Episode - Death: The High Cos...`
Trak episode's name `A Special Episode - Death: The High Cost of Living`