### PR TITLE
fix(matching): Hardcode Arrested Development Season 4 Remix

### DIFF
--- a/internal/netflix/parse_title_test.go
+++ b/internal/netflix/parse_title_test.go
@@ -174,8 +174,8 @@ func TestParseTitle(t *testing.T) {
 			title: `Arrested Development: Season 4 Remix: Fateful Consequences: "A Couple-A New Starts"`,
 			expected: &netflix.WatchActivity{
 				Title:       "Arrested Development",
-				Season:      4,
-				EpisodeName: "A Couple-A New Starts",
+				Season:      0,
+				EpisodeName: "Season 4 Remix: A Couple-A New Starts",
 				IsShow:      true,
 			},
 		},


### PR DESCRIPTION
Both Netflix and trakt handles Season 4 differently.

Season 4 Remix is what Netflix gives you as Season 4. The thing is, there used to be another season 4, which Netflix now hides in the "Trailers & More" sections.

Anything in `Trailers & More` won't show in Netflix's watch activity (the one on their website that is), so we cannot trakt the OG season 4 anymore.

Since the original Season 4 used to be on Netflix under the regular "Season 4" section (before they did a Remix), Trakt treats the OG season 4 as the real season 4, and treats the remix as a "Special".

This means that what's on Netflix seems to be the 11th episode of Season 4, is the 16th episode of Season 0 in Trakt (Because they put all the Specials under season 0).