### PR TITLE
fix(trakt): Increase timeout and add a backoff retry

### DIFF
--- a/internal/trakt/client.go
+++ b/internal/trakt/client.go
@@ -22,6 +22,12 @@ import (
 
 const traktErrorCodeURL = "https://trakt.docs.apiary.io/#introduction/status-codes"
 
+const (
+	traktHTTPTimeout            = 30 * time.Second
+	traktTransientRetryAttempts = 3
+	traktTransientRetryDelay    = 250 * time.Millisecond
+)
+
 // ErrPendingAuthorization is returned when the authorization is still
 // pending, waiting for the user to complete the authorization flow.
 var ErrPendingAuthorization = errors.New("pending authorization")
@@ -41,6 +47,8 @@ type AccessTokenInfo struct {
 type Client struct {
 	// http is the HTTP client used to make requests to the Trakt API.
 	http *http.Client
+	// retrySleep waits between bounded retry attempts.
+	retrySleep func(time.Duration)
 	// baseURL is the base URL for the Trakt API.
 	baseURL string
 	// clientID is the client ID of the Trakt APP.
@@ -87,8 +95,9 @@ func NewClient(cfg ClientConfig) (clt *Client, err error) {
 
 	return &Client{
 		http: &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: traktHTTPTimeout,
 		},
+		retrySleep:   time.Sleep,
 		baseURL:      "https://api.trakt.tv",
 		clientID:     cfg.ClientID,
 		clientSecret: cfg.ClientSecret,
@@ -132,25 +141,33 @@ func (c *Client) request(ctx context.Context, method, path string, body json.Raw
 		o(&options)
 	}
 
-	var bodyBuffer io.Reader = http.NoBody
-	if body != nil {
-		bodyBuffer = bytes.NewBuffer(body)
-	}
-
-	resp, respBody, err = c._request(ctx, method, path, bodyBuffer, options)
-	if err != nil {
-		return nil, nil, err
-	}
-	if !options.noAuth && !options.dontRetryOnAuthFailure && resp.StatusCode == http.StatusUnauthorized {
-		_, err := c.RefreshToken(ctx, c.auth.RefreshToken.Get())
-		if err != nil {
-			return nil, nil, fmt.Errorf("refresh token: %w", err)
+	for attempt := range traktTransientRetryAttempts {
+		var bodyBuffer io.Reader = http.NoBody
+		if body != nil {
+			bodyBuffer = bytes.NewReader(body)
 		}
-		newOpts := append(opts, withNoRetryOnAuthFailure()) //nolint:gocritic // appendAssign it's expected that we create a new list
-		return c.request(ctx, method, path, body, newOpts...)
+
+		resp, respBody, err = c._request(ctx, method, path, bodyBuffer, options)
+		if err != nil {
+			if resp == nil && shouldRetryTransientRequest(ctx, err, attempt) {
+				c.sleepBeforeRetry(traktRetryDelay(attempt))
+				continue
+			}
+			return resp, respBody, err
+		}
+		if !options.noAuth && !options.dontRetryOnAuthFailure && resp.StatusCode == http.StatusUnauthorized {
+			_, err := c.RefreshToken(ctx, c.auth.RefreshToken.Get())
+			if err != nil {
+				return nil, nil, fmt.Errorf("refresh token: %w", err)
+			}
+			newOpts := append(opts, withNoRetryOnAuthFailure()) //nolint:gocritic // appendAssign it's expected that we create a new list
+			return c.request(ctx, method, path, body, newOpts...)
+		}
+
+		return resp, respBody, nil
 	}
 
-	return resp, respBody, nil
+	return nil, nil, err
 }
 
 // _request is a low-level HTTP request function that sends a request to the
@@ -182,10 +199,30 @@ func (c *Client) _request(ctx context.Context, method, path string, body io.Read
 
 	respBody, err = io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, nil, fmt.Errorf("read response body: %w", err)
+		return resp, nil, fmt.Errorf("read response body: %w", err)
 	}
 
 	return resp, respBody, nil
+}
+
+func shouldRetryTransientRequest(ctx context.Context, err error, attempt int) bool {
+	if ctx.Err() != nil || attempt >= traktTransientRetryAttempts-1 {
+		return false
+	}
+
+	return errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err)
+}
+
+func traktRetryDelay(attempt int) time.Duration {
+	return time.Duration(attempt+1) * traktTransientRetryDelay
+}
+
+func (c *Client) sleepBeforeRetry(delay time.Duration) {
+	if c.retrySleep != nil {
+		c.retrySleep(delay)
+		return
+	}
+	time.Sleep(delay)
 }
 
 func (c *Client) post(ctx context.Context, path string, body any, opts ...requestOptionsFunc) (resp *http.Response, respBody []byte, err error) {

--- a/internal/trakt/client_test.go
+++ b/internal/trakt/client_test.go
@@ -1,15 +1,25 @@
 package trakt
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Nivl/trakt-netflix/internal/secret"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
 
 func TestSearch(t *testing.T) {
 	t.Parallel()
@@ -165,4 +175,117 @@ func TestGetSeasonEpisodes(t *testing.T) {
 	require.Len(t, episodes, 1)
 	assert.Equal(t, "/shows/search-party/seasons/2", gotPath)
 	assert.Equal(t, "Episode 1", episodes[0].Title)
+}
+
+func TestSearchRetriesTransientTransportTimeouts(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	client := new(Client)
+	client.http = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts < 3 {
+				return nil, &url.Error{
+					Op:  req.Method,
+					URL: req.URL.String(),
+					Err: context.DeadlineExceeded,
+				}
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("[]")),
+				Request:    req,
+			}, nil
+		}),
+	}
+	client.baseURL = "https://example.test"
+	client.clientID = "test-client-id"
+	client.clientSecret = secret.NewSecret("")
+	client.retrySleep = func(time.Duration) {}
+
+	searchResponse, err := client.Search(t.Context(), SearchRequest{
+		Type:  SearchTypeMovie,
+		Query: "Pain Hustlers",
+		Show:  "",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, searchResponse)
+	assert.Empty(t, searchResponse.Results)
+	assert.Equal(t, 3, attempts)
+}
+
+func TestGenerateAuthCodeRetriesTransientTransportTimeoutsAndReplaysBody(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	var bodies []string
+	client := new(Client)
+	client.http = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			payload, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			bodies = append(bodies, string(payload))
+
+			attempts++
+			if attempts == 1 {
+				return nil, &url.Error{
+					Op:  req.Method,
+					URL: req.URL.String(),
+					Err: context.DeadlineExceeded,
+				}
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"device_code":"device","user_code":"user","verification_url":"https://trakt.tv/activate","expires_in":600,"interval":5}`)),
+				Request:    req,
+			}, nil
+		}),
+	}
+	client.baseURL = "https://example.test"
+	client.clientID = "test-client-id"
+	client.clientSecret = secret.NewSecret("")
+	client.retrySleep = func(time.Duration) {}
+
+	resp, err := client.GenerateAuthCode(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 2, attempts)
+	assert.Equal(t, []string{`{"client_id":"test-client-id"}`, `{"client_id":"test-client-id"}`}, bodies)
+}
+
+func TestSearchDoesNotRetryWhenServerResponds(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	client := new(Client)
+	client.http = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return &http.Response{
+				StatusCode: http.StatusGatewayTimeout,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":"timeout"}`)),
+				Request:    req,
+			}, nil
+		}),
+	}
+	client.baseURL = "https://example.test"
+	client.clientID = "test-client-id"
+	client.clientSecret = secret.NewSecret("")
+	client.retrySleep = func(time.Duration) {}
+
+	searchResponse, err := client.Search(t.Context(), SearchRequest{
+		Type:  SearchTypeMovie,
+		Query: "Pain Hustlers",
+		Show:  "",
+	})
+	require.Nil(t, searchResponse)
+	require.Error(t, err)
+	assert.Equal(t, 1, attempts)
+	assert.ErrorContains(t, err, "http 504")
 }


### PR DESCRIPTION
The trakt API has been timing out a lot lately. This PR tries to reduce the likelyhood of having a failure. 